### PR TITLE
try_files removed from nginx.config

### DIFF
--- a/.local-dev-config/nginx.conf
+++ b/.local-dev-config/nginx.conf
@@ -5,6 +5,5 @@ server {
     location / {
         root   /usr/share/nginx/html/build;
         index  index.html index.htm;
-        try_files $uri $uri/ /index.html;
     }
 }


### PR DESCRIPTION
Don't redirect to index.html by default.