### PR TITLE
Redirect /images in local dev setup

### DIFF
--- a/.local-dev-config/nginx.conf
+++ b/.local-dev-config/nginx.conf
@@ -6,4 +6,18 @@ server {
         root   /usr/share/nginx/html/build;
         index  index.html index.htm;
     }
+
+    location ~ ^/images/(https?://.+)$ {
+        resolver 8.8.8.8;
+        proxy_pass $1;
+        proxy_set_header Host $proxy_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_ssl_server_name on;
+        
+        # CORS headers
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+    }
 }


### PR DESCRIPTION
When <entry key="image_prefix" value="/images/"/> is set in prefs.xml, images are redirected correctly in the local development environment.

Example:

source.xml
```xml
<surface xml:id="surface_5060a968-9703-44fb-ae73-98d7008d2e93" n="1" ulx="0" uly="0" lrx="4119" lry="5246">
    <graphic xml:id="graphic_2d4b950a-8510-4480-b76f-736b9269ae70" target="https://dev.korngold-werkausgabe.de/Scaler/IIIF/US-Wc%21KC25-13%21US-Wc_KC25-13_001r" type="facsimile" width="4119" height="5246"/>
</surface>
```

prefs.xml
```xml
<entry key="image_prefix" value="/images/"/>
```